### PR TITLE
Allow Js.Null.t on optional input type fields

### DIFF
--- a/compiler/crates/relay-typegen/src/rescript_utils.rs
+++ b/compiler/crates/relay-typegen/src/rescript_utils.rs
@@ -343,9 +343,9 @@ fn print_wrapped_in_some(str: &String, print_as_optional: bool) -> String {
     }
 }
 
-fn print_opt(str: &String, optional: bool) -> String {
-    if optional {
-        format!("option<{}>", str)
+pub fn print_nullable(str: &String, nullable: bool) -> String {
+    if nullable {
+        format!("Js.Null.t<{}>", str)
     } else {
         format!("{}", str)
     }
@@ -412,8 +412,7 @@ pub fn print_type_reference(
     prefix_with_schema_module: bool,
 ) -> String {
     match typ {
-        TypeReference::Named(named_type) => print_opt(
-            &match named_type {
+        TypeReference::Named(named_type) => print_nullable( &match named_type {
                 Type::Enum(id) => format!(
                     "[{}]",
                     schema
@@ -467,17 +466,17 @@ pub fn print_type_reference(
             },
             nullable,
         ),
-        TypeReference::NonNull(typ) => format!(
-            "{}",
-            print_type_reference(
+        TypeReference::NonNull(typ) => print_nullable(
+            &print_type_reference(
                 &typ,
                 &schema,
                 &custom_scalar_types,
                 false,
                 prefix_with_schema_module
-            )
+            ),
+            nullable
         ),
-        TypeReference::List(typ) => print_opt(
+        TypeReference::List(typ) => print_nullable(
             &format!(
                 "array<{}>",
                 print_type_reference(
@@ -488,7 +487,7 @@ pub fn print_type_reference(
                     prefix_with_schema_module
                 )
             ),
-            nullable,
+            nullable
         ),
     }
 }

--- a/compiler/test-project-res/src/__generated__/RelaySchemaAssets_graphql.res
+++ b/compiler/test-project-res/src/__generated__/RelaySchemaAssets_graphql.res
@@ -31,100 +31,100 @@ type enum_RequiredFieldAction_input = [
 
 @live
 type rec input_InputA = {
-  time: SomeModule.Datetime.t,
-  recursiveA: option<input_InputA>,
-  usingB: option<input_InputB>,
-  timestamp: option<Timestamp.t>,
-  timestamps: option<array<option<Timestamp.t>>>,
-  unmapped: option<RescriptRelay.any>,
+  time: Js.Null.t<SomeModule.Datetime.t>,
+  recursiveA?: Js.Null.t<input_InputA>,
+  usingB?: Js.Null.t<input_InputB>,
+  timestamp?: Js.Null.t<Timestamp.t>,
+  timestamps?: Js.Null.t<array<Js.Null.t<Timestamp.t>>>,
+  unmapped?: Js.Null.t<RescriptRelay.any>,
 }
 
 @live
 and input_InputB = {
-  time: option<SomeModule.Datetime.t>,
-  usingA: option<input_InputA>,
-  @as("constraint") constraint_: option<bool>,
+  time?: Js.Null.t<SomeModule.Datetime.t>,
+  usingA?: Js.Null.t<input_InputA>,
+  @as("constraint") constraint_?: Js.Null.t<bool>,
 }
 
 @live
 and input_SomeInput = {
-  str: option<string>,
-  bool: option<bool>,
-  float: option<float>,
-  int: option<int>,
-  datetime: option<SomeModule.Datetime.t>,
-  recursive: option<input_SomeInput>,
-  @as("private") private_: option<bool>,
+  str?: Js.Null.t<string>,
+  bool?: Js.Null.t<bool>,
+  float?: Js.Null.t<float>,
+  int?: Js.Null.t<int>,
+  datetime?: Js.Null.t<SomeModule.Datetime.t>,
+  recursive?: Js.Null.t<input_SomeInput>,
+  @as("private") private_?: Js.Null.t<bool>,
 }
 
 @live
 and input_RecursiveSetOnlineStatusInput = {
-  someValue: RescriptRelay.any,
-  setOnlineStatus: option<input_SetOnlineStatusInput>,
+  someValue: Js.Null.t<RescriptRelay.any>,
+  setOnlineStatus?: Js.Null.t<input_SetOnlineStatusInput>,
 }
 
 @live
 and input_SetOnlineStatusInput = {
-  onlineStatus: [#Online | #Idle | #Offline],
-  recursed: option<input_RecursiveSetOnlineStatusInput>,
+  onlineStatus: Js.Null.t<[#Online | #Idle | #Offline]>,
+  recursed?: Js.Null.t<input_RecursiveSetOnlineStatusInput>,
 }
 
 @live
 and input_PesticideListSearchInput = {
-  companyName: option<array<string>>,
-  pesticideIds: option<array<int>>,
-  skip: int,
-  take: int,
+  companyName?: Js.Null.t<array<Js.Null.t<string>>>,
+  pesticideIds?: Js.Null.t<array<Js.Null.t<int>>>,
+  skip: Js.Null.t<int>,
+  take: Js.Null.t<int>,
 }
 @live @obj
 external make_InputA: (
   ~time: SomeModule.Datetime.t,
-  ~recursiveA: input_InputA=?,
-  ~usingB: input_InputB=?,
-  ~timestamp: Timestamp.t=?,
-  ~timestamps: array<option<Timestamp.t>>=?,
-  ~unmapped: RescriptRelay.any=?,
+  ~recursiveA: Js.Null.t<input_InputA>=?,
+  ~usingB: Js.Null.t<input_InputB>=?,
+  ~timestamp: Js.Null.t<Timestamp.t>=?,
+  ~timestamps: Js.Null.t<array<Js.Null.t<Timestamp.t>>>=?,
+  ~unmapped: Js.Null.t<RescriptRelay.any>=?,
   unit,
 ) => input_InputA = ""
 
 @live @obj
 external make_InputB: (
-  ~time: SomeModule.Datetime.t=?,
-  ~usingA: input_InputA=?,
-  ~_constraint: bool=?,
+  ~time: Js.Null.t<SomeModule.Datetime.t>=?,
+  ~usingA: Js.Null.t<input_InputA>=?,
+  ~_constraint: Js.Null.t<bool>=?,
   unit,
 ) => input_InputB = ""
 
 @live @obj
 external make_SomeInput: (
-  ~str: string=?,
-  ~bool: bool=?,
-  ~float: float=?,
-  ~int: int=?,
-  ~datetime: SomeModule.Datetime.t=?,
-  ~recursive: input_SomeInput=?,
-  ~_private: bool=?,
+  ~str: Js.Null.t<string>=?,
+  ~bool: Js.Null.t<bool>=?,
+  ~float: Js.Null.t<float>=?,
+  ~int: Js.Null.t<int>=?,
+  ~datetime: Js.Null.t<SomeModule.Datetime.t>=?,
+  ~recursive: Js.Null.t<input_SomeInput>=?,
+  ~_private: Js.Null.t<bool>=?,
   unit,
 ) => input_SomeInput = ""
 
 @live @obj
 external make_RecursiveSetOnlineStatusInput: (
   ~someValue: RescriptRelay.any,
-  ~setOnlineStatus: input_SetOnlineStatusInput=?,
+  ~setOnlineStatus: Js.Null.t<input_SetOnlineStatusInput>=?,
   unit,
 ) => input_RecursiveSetOnlineStatusInput = ""
 
 @live @obj
 external make_SetOnlineStatusInput: (
   ~onlineStatus: [#Online | #Idle | #Offline],
-  ~recursed: input_RecursiveSetOnlineStatusInput=?,
+  ~recursed: Js.Null.t<input_RecursiveSetOnlineStatusInput>=?,
   unit,
 ) => input_SetOnlineStatusInput = ""
 
 @live @obj
 external make_PesticideListSearchInput: (
-  ~companyName: array<string>=?,
-  ~pesticideIds: array<int>=?,
+  ~companyName: Js.Null.t<array<Js.Null.t<string>>>=?,
+  ~pesticideIds: Js.Null.t<array<Js.Null.t<int>>>=?,
   ~skip: int,
   ~take: int,
   unit,

--- a/compiler/test-project-res/src/__generated__/TestConnectionsUnion_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestConnectionsUnion_user_graphql.res
@@ -78,7 +78,7 @@ let connectionKey = "TestConnections_user_friendsConnection"
 )
 
 @live
-let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~onlineStatuses: array<[#Online | #Idle | #Offline]>=[#Idle], ~beforeDate: SomeModule.Datetime.t, ~someInput: option<RelaySchemaAssets_graphql.input_SomeInput>=?, ()) => {
+let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~onlineStatuses: Js.Null.t<array<Js.Null.t<[#Online | #Idle | #Offline]>>>=[#Idle], ~beforeDate: Js.Null.t<SomeModule.Datetime.t>, ~someInput: Js.Null.t<RelaySchemaAssets_graphql.input_SomeInput>=?, ()) => {
   let onlineStatuses = Some(onlineStatuses)
   let beforeDate = Some(SomeModule.Datetime.serialize(beforeDate))
   let args = {"statuses": onlineStatuses, "beforeDate": beforeDate, "objTests": [RescriptRelay_Internal.Arg(Some({"int": Some(123)})), RescriptRelay_Internal.Arg(Some({"str": Some("Hello")})), RescriptRelay_Internal.Arg(someInput)]}

--- a/compiler/test-project-res/src/__generated__/TestConnectionsWithConstantValues_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestConnectionsWithConstantValues_user_graphql.res
@@ -50,7 +50,7 @@ let connectionKey = "TestConnectionsWithonstantValues_user_friendsConnection"
 )
 
 @live
-let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~onlineStatus: [#Online | #Idle | #Offline], ~beforeDate: SomeModule.Datetime.t, ~datetime: Js.null<SomeModule.Datetime.t>=Js.null, ~bool: option<bool>=?, ~flt: Js.null<float>=Js.null, ~datetime2: option<SomeModule.Datetime.t>=?, ~datetime3: SomeModule.Datetime.t, ()) => {
+let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~onlineStatus: Js.Null.t<[#Online | #Idle | #Offline]>, ~beforeDate: Js.Null.t<SomeModule.Datetime.t>, ~datetime: Js.null<Js.Null.t<SomeModule.Datetime.t>>=Js.null, ~bool: Js.Null.t<bool>=?, ~flt: Js.null<Js.Null.t<float>>=Js.null, ~datetime2: Js.Null.t<SomeModule.Datetime.t>=?, ~datetime3: Js.Null.t<SomeModule.Datetime.t>, ()) => {
   let onlineStatus = Some(onlineStatus)
   let beforeDate = Some(SomeModule.Datetime.serialize(beforeDate))
   let datetime = datetime->Js.Null.toOption

--- a/compiler/test-project-res/src/__generated__/TestConnectionsWithFilters_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestConnectionsWithFilters_user_graphql.res
@@ -50,7 +50,7 @@ let connectionKey = "TestConnectionsWithFilters_user_friendsConnection"
 )
 
 @live
-let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~onlineStatuses: option<array<[#Online | #Idle | #Offline]>>=?, ~objTest: RelaySchemaAssets_graphql.input_SomeInput=Obj.magic({"str": "123"}), ()) => {
+let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~onlineStatuses: Js.Null.t<array<Js.Null.t<[#Online | #Idle | #Offline]>>>=?, ~objTest: Js.Null.t<RelaySchemaAssets_graphql.input_SomeInput>=Obj.magic({"str": "123"}), ()) => {
   let objTest = Some(objTest)
   let args = {"statuses": onlineStatuses, "objTest": objTest}
   internal_makeConnectionId(connectionParentDataId, args)

--- a/compiler/test-project-res/src/__generated__/TestConnections_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestConnections_user_graphql.res
@@ -50,7 +50,7 @@ let connectionKey = "TestConnections_user_friendsConnection"
 )
 
 @live
-let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~onlineStatuses: array<[#Online | #Idle | #Offline]>=[#Idle], ~beforeDate: SomeModule.Datetime.t, ()) => {
+let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~onlineStatuses: Js.Null.t<array<Js.Null.t<[#Online | #Idle | #Offline]>>>=[#Idle], ~beforeDate: Js.Null.t<SomeModule.Datetime.t>, ()) => {
   let onlineStatuses = Some(onlineStatuses)
   let beforeDate = Some(SomeModule.Datetime.serialize(beforeDate))
   let args = {"statuses": onlineStatuses, "beforeDate": beforeDate}

--- a/compiler/test-project-res/src/__generated__/TestPaginationInNode_query_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestPaginationInNode_query_graphql.res
@@ -52,7 +52,7 @@ let connectionKey = "TestPaginationInNode_friendsConnection"
 )
 
 @live
-let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~onlineStatuses: option<array<[#Online | #Idle | #Offline]>>=?, ()) => {
+let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~onlineStatuses: Js.Null.t<array<Js.Null.t<[#Online | #Idle | #Offline]>>>=?, ()) => {
   let args = {"statuses": onlineStatuses}
   internal_makeConnectionId(connectionParentDataId, args)
 }

--- a/compiler/test-project-res/src/__generated__/TestPaginationUnion_query_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestPaginationUnion_query_graphql.res
@@ -97,7 +97,7 @@ let connectionKey = "TestPaginationUnion_query_members"
 )
 
 @live
-let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~groupId: string, ~onlineStatuses: option<array<[#Online | #Idle | #Offline]>>=?, ()) => {
+let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~groupId: Js.Null.t<string>, ~onlineStatuses: Js.Null.t<array<Js.Null.t<[#Online | #Idle | #Offline]>>>=?, ()) => {
   let groupId = Some(groupId)
   let args = {"groupId": groupId, "onlineStatuses": onlineStatuses}
   internal_makeConnectionId(connectionParentDataId, args)


### PR DESCRIPTION
Also:
- Use optional record field syntax (e.g. "optional?: string") in input types

references: https://github.com/zth/rescript-relay/issues/348