### PR TITLE
More informative warning about not finding edges, node

### DIFF
--- a/compiler/crates/relay-typegen/src/rescript.rs
+++ b/compiler/crates/relay-typegen/src/rescript.rs
@@ -1618,12 +1618,12 @@ fn write_get_connection_nodes_function(
         {
             match find_object_with_record_name(&edges_obj_type_name, state) {
                 None => {
-                    warn!("Could not find edges object.")
+                    warn!("Could not find edges object from connection: {}", connection_field_name)
                 }
                 Some(edges_object) => {
                     // Find the node
                     match find_prop_at_key(&edges_object, &String::from("node")) {
-                        None => warn!("Could not find node"),
+                        None => warn!("Could not find node from connection {}", connection_field_name),
                         Some(prop_value) => {
                             let (node_nullable, node_type_name) =
                                 match &prop_value.prop_type.as_ref() {


### PR DESCRIPTION
While using the 3.0-rc version, I noticed that the compiler keeps throwing a `Could not find node` warning in the console. With the lack of information, it's hard to tell what's causing the error, so I'd like to suggest showing the connection name in the warning.
I wasn't able to build PPX with esy locally, so I couldn't really test it. This PR is a feature suggestion, so you can take a look and close it.