### PR TITLE
NonReact

### DIFF
--- a/compiler/crates/common/src/rescript_utils.rs
+++ b/compiler/crates/common/src/rescript_utils.rs
@@ -22,7 +22,7 @@ pub fn get_load_fn_code() -> StringKey {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,
@@ -35,7 +35,7 @@ pub fn get_load_fn_code() -> StringKey {
     .intern()
 }
 
-pub fn get_load_query_code(include_load_fn: bool) -> StringKey {
+pub fn get_load_query_code(include_load_fn: bool, non_react: bool) -> StringKey {
     format!(
         "{}
 
@@ -56,7 +56,7 @@ let queryRefToPromise = token => {{
     }}
   }})
 }}",
-        if include_load_fn {
+        if include_load_fn && !non_react {
             get_load_fn_code()
         } else {
             "".intern()

--- a/compiler/crates/common/src/rescript_utils.rs
+++ b/compiler/crates/common/src/rescript_utils.rs
@@ -35,7 +35,7 @@ pub fn get_load_fn_code() -> StringKey {
     .intern()
 }
 
-pub fn get_load_query_code(include_load_fn: bool, non_react: bool) -> StringKey {
+pub fn get_load_query_code(include_load_fn: bool) -> StringKey {
     format!(
         "{}
 
@@ -56,7 +56,7 @@ let queryRefToPromise = token => {{
     }}
   }})
 }}",
-        if include_load_fn && !non_react {
+        if include_load_fn {
             get_load_fn_code()
         } else {
             "".intern()

--- a/compiler/crates/relay-compiler/src/artifact_content/content.rs
+++ b/compiler/crates/relay-compiler/src/artifact_content/content.rs
@@ -1225,8 +1225,8 @@ pub fn generate_operation_rescript(
         "{}",
         match typegen_operation.kind {
             graphql_syntax::OperationKind::Query => get_load_query_code(
-                !is_operation_preloadable(normalization_operation),
-                project_config.rescript_relay_mode == RescriptRelayMode::NonReact,
+                !is_operation_preloadable(normalization_operation)
+                    && project_config.rescript_relay_mode != RescriptRelayMode::NonReact,
             ),
             graphql_syntax::OperationKind::Mutation
             | graphql_syntax::OperationKind::Subscription => "".intern()

--- a/compiler/crates/relay-compiler/src/artifact_content/content.rs
+++ b/compiler/crates/relay-compiler/src/artifact_content/content.rs
@@ -47,6 +47,7 @@ use super::rescript_relay_utils::write_codesplit_components;
 use super::rescript_relay_utils::write_codesplits_node_modifier;
 use crate::config::Config;
 use crate::config::ProjectConfig;
+use crate::config::RescriptRelayMode;
 
 pub fn generate_preloadable_query_parameters(
     config: &Config,
@@ -1223,7 +1224,10 @@ pub fn generate_operation_rescript(
         section,
         "{}",
         match typegen_operation.kind {
-            graphql_syntax::OperationKind::Query => get_load_query_code(!is_operation_preloadable(normalization_operation)),
+            graphql_syntax::OperationKind::Query => get_load_query_code(
+                !is_operation_preloadable(normalization_operation),
+                project_config.rescript_relay_mode == RescriptRelayMode::NonReact,
+            ),
             graphql_syntax::OperationKind::Mutation
             | graphql_syntax::OperationKind::Subscription => "".intern()
         }

--- a/compiler/crates/relay-compiler/src/config.rs
+++ b/compiler/crates/relay-compiler/src/config.rs
@@ -41,6 +41,7 @@ pub use relay_config::LocalPersistConfig;
 use relay_config::ModuleImportConfig;
 pub use relay_config::PersistConfig;
 pub use relay_config::ProjectConfig;
+pub use relay_config::RescriptRelayMode;
 use relay_config::ProjectName;
 pub use relay_config::RemotePersistConfig;
 use relay_config::ResolversSchemaModuleConfig;
@@ -440,6 +441,9 @@ impl Config {
                     codegen_command: config_file_project.codegen_command,
                     input_unions: config_file_project.input_unions,
                     get_custom_path_for_artifact: None,
+                    rescript_relay_mode: config_file_project
+                        .rescript_relay_mode
+                        .unwrap_or(RescriptRelayMode::Default),
                 };
                 Ok((project_name, project_config))
             })
@@ -965,6 +969,10 @@ pub struct SingleProjectConfigFile {
     /// A placeholder for allowing extra information in the config file
     #[serde(default)]
     pub extra: serde_json::Value,
+
+    /// RescriptRelay mode toggle (Default | NonReact). Default is React-enabled.
+    #[serde(default)]
+    pub rescript_relay_mode: Option<RescriptRelayMode>,
 }
 
 impl Default for SingleProjectConfigFile {
@@ -990,6 +998,7 @@ impl Default for SingleProjectConfigFile {
             input_unions: Default::default(),
             no_source_control: Some(false),
             extra: Default::default(),
+            rescript_relay_mode: Default::default(),
         }
     }
 }
@@ -1074,6 +1083,7 @@ impl SingleProjectConfigFile {
             resolvers_schema_module: self.resolvers_schema_module,
             input_unions: self.input_unions,
             extra: self.extra,
+            rescript_relay_mode: self.rescript_relay_mode,
             ..Default::default()
         };
 
@@ -1270,6 +1280,10 @@ pub struct ConfigFileProject {
 
     #[serde(default)]
     pub input_unions: Option<Vec<StringKey>>,
+
+    /// RescriptRelay mode toggle (Default | NonReact). Default is React-enabled.
+    #[serde(default)]
+    pub rescript_relay_mode: Option<RescriptRelayMode>,
 }
 
 pub type PersistId = String;

--- a/compiler/crates/relay-config/src/lib.rs
+++ b/compiler/crates/relay-config/src/lib.rs
@@ -34,6 +34,7 @@ pub use project_config::LocalPersistAlgorithm;
 pub use project_config::LocalPersistConfig;
 pub use project_config::PersistConfig;
 pub use project_config::ProjectConfig;
+pub use project_config::RescriptRelayMode;
 pub use project_config::RemotePersistConfig;
 pub use project_config::SchemaConfig;
 pub use project_config::SchemaLocation;

--- a/compiler/crates/relay-config/src/project_config.rs
+++ b/compiler/crates/relay-config/src/project_config.rs
@@ -323,6 +323,9 @@ pub struct ProjectConfig {
     /// Treats JS module paths as relative to './' when true, and leaves JS
     /// module paths unmodified when false.
     pub relativize_js_module_paths: bool,
+    /// Mode for RescriptRelay-specific codegen tweaks.
+    /// Default: React-enabled (loadQuery emitted). NonReact: omit React helpers.
+    pub rescript_relay_mode: RescriptRelayMode,
 }
 
 impl Default for ProjectConfig {
@@ -358,6 +361,7 @@ impl Default for ProjectConfig {
             input_unions: Default::default(),
             get_custom_path_for_artifact: None,
             relativize_js_module_paths: true,
+            rescript_relay_mode: RescriptRelayMode::Default,
         }
     }
 }
@@ -395,6 +399,7 @@ impl Debug for ProjectConfig {
             input_unions,
             get_custom_path_for_artifact: _,
             relativize_js_module_paths,
+            rescript_relay_mode,
         } = self;
         f.debug_struct("ProjectConfig")
             .field("name", name)
@@ -426,6 +431,7 @@ impl Debug for ProjectConfig {
             .field("codegen_command", codegen_command)
             .field("input_unions", input_unions)
             .field("relativize_js_module_paths", relativize_js_module_paths)
+            .field("rescript_relay_mode", rescript_relay_mode)
             .finish()
     }
 }
@@ -551,4 +557,18 @@ fn format_normalized_path(path: &Path) -> String {
     path.to_string_lossy()
         .to_string()
         .replace(MAIN_SEPARATOR, "/")
+}
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub enum RescriptRelayMode {
+    #[serde(rename = "Default")]
+    Default,
+    #[serde(rename = "NonReact")]
+    NonReact,
+}
+
+impl Default for RescriptRelayMode {
+    fn default() -> Self {
+        RescriptRelayMode::Default
+    }
 }

--- a/compiler/test-project-res-preloadable/src/__generated__/TestPreloadedQueryWithCodesplitQuery_preloadable_graphql.res
+++ b/compiler/test-project-res-preloadable/src/__generated__/TestPreloadedQueryWithCodesplitQuery_preloadable_graphql.res
@@ -59,7 +59,7 @@ let node = RescriptRelay_Internal.applyCodesplitMetadata(node, [
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res-preloadable/src/__generated__/TestPreloadedQueryWithProvidedVariablesQuery_preloadable_graphql.res
+++ b/compiler/test-project-res-preloadable/src/__generated__/TestPreloadedQueryWithProvidedVariablesQuery_preloadable_graphql.res
@@ -118,7 +118,7 @@ let node: operationType = makeNode(providedVariablesDefinition)
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res-preloadable/src/__generated__/TestPreloadedQuery_preloadable_graphql.res
+++ b/compiler/test-project-res-preloadable/src/__generated__/TestPreloadedQuery_preloadable_graphql.res
@@ -58,7 +58,7 @@ let node: operationType = %raw(json` {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestCatchAndFriends2Query_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestCatchAndFriends2Query_graphql.res
@@ -294,7 +294,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestCatchAndFriends3Query_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestCatchAndFriends3Query_graphql.res
@@ -259,7 +259,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestCatchAndFriendsQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestCatchAndFriendsQuery_graphql.res
@@ -181,7 +181,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestCodesplitQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestCodesplitQuery_graphql.res
@@ -502,7 +502,7 @@ let node = RescriptRelay_Internal.applyCodesplitMetadata(node, [
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestCustomScalars2Query_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestCustomScalars2Query_graphql.res
@@ -153,7 +153,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestCustomScalarsQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestCustomScalarsQuery_graphql.res
@@ -374,7 +374,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestFragmentQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestFragmentQuery_graphql.res
@@ -336,7 +336,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestLocalPayloadQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestLocalPayloadQuery_graphql.res
@@ -206,7 +206,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestLocalPayloadViaNodeInterfaceQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestLocalPayloadViaNodeInterfaceQuery_graphql.res
@@ -289,7 +289,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestMissingFieldHandlersMeQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestMissingFieldHandlersMeQuery_graphql.res
@@ -163,7 +163,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestMissingFieldHandlersQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestMissingFieldHandlersQuery_graphql.res
@@ -199,7 +199,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestModelResolverAliasedQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestModelResolverAliasedQuery_graphql.res
@@ -346,7 +346,7 @@ let node: operationType = makeNode(LocalUser__id_graphql.node, LocalUser____rela
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestModelResolverInlineQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestModelResolverInlineQuery_graphql.res
@@ -346,7 +346,7 @@ let node: operationType = makeNode(LocalUser__id_graphql.node, LocalUser____rela
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestMutationQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestMutationQuery_graphql.res
@@ -237,7 +237,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestNodeInterfaceOnInterfaceQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestNodeInterfaceOnInterfaceQuery_graphql.res
@@ -195,7 +195,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestNodeInterfaceOnUnionQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestNodeInterfaceOnUnionQuery_graphql.res
@@ -235,7 +235,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestNodeInterfaceQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestNodeInterfaceQuery_graphql.res
@@ -199,7 +199,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestObserverQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestObserverQuery_graphql.res
@@ -143,7 +143,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestPaginationInNodeQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestPaginationInNodeQuery_graphql.res
@@ -330,7 +330,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestPaginationInNodeRefetchQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestPaginationInNodeRefetchQuery_graphql.res
@@ -394,7 +394,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestPaginationUnionQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestPaginationUnionQuery_graphql.res
@@ -360,7 +360,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestPaginationUnionRefetchQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestPaginationUnionRefetchQuery_graphql.res
@@ -420,7 +420,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestProvidedVariablesQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestProvidedVariablesQuery_graphql.res
@@ -323,7 +323,7 @@ let node: operationType = makeNode(providedVariablesDefinition)
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestQueryInputObjQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestQueryInputObjQuery_graphql.res
@@ -152,7 +152,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestQueryWithRequiredQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestQueryWithRequiredQuery_graphql.res
@@ -167,7 +167,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestQueryWithRequired_BubbleToTop_Query_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestQueryWithRequired_BubbleToTop_Query_graphql.res
@@ -172,7 +172,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestQuery_graphql.res
@@ -259,7 +259,7 @@ let node: operationType = makeNode(RescriptRelay.resolverDataInjector, TestRelay
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestRefetchingInNodeQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestRefetchingInNodeQuery_graphql.res
@@ -252,7 +252,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestRefetchingInNodeRefetchQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestRefetchingInNodeRefetchQuery_graphql.res
@@ -299,7 +299,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestRefetchingNoArgsRefetchQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestRefetchingNoArgsRefetchQuery_graphql.res
@@ -144,7 +144,7 @@ let node: operationType = %raw(json` {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestRefetchingQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestRefetchingQuery_graphql.res
@@ -182,7 +182,7 @@ let node: operationType = %raw(json` {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestRefetchingRefetchQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestRefetchingRefetchQuery_graphql.res
@@ -296,7 +296,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestRelayResolversAllQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestRelayResolversAllQuery_graphql.res
@@ -346,7 +346,7 @@ let node: operationType = makeNode(LocalUser__id_graphql.node, LocalUser____rela
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestSchemaExtensionsQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestSchemaExtensionsQuery_graphql.res
@@ -198,7 +198,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestSubscriptionQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestSubscriptionQuery_graphql.res
@@ -178,7 +178,7 @@ let node: operationType = %raw(json` {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestUnionFragmentExhaustiveQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestUnionFragmentExhaustiveQuery_graphql.res
@@ -213,7 +213,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestUnionFragmentQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestUnionFragmentQuery_graphql.res
@@ -234,7 +234,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,

--- a/compiler/test-project-res/src/__generated__/TestUnionsQuery_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestUnionsQuery_graphql.res
@@ -411,7 +411,7 @@ return {
   ~fetchKey=?,
   ~networkCacheConfig=?,
 ) =>
-  RescriptRelay.loadQuery(
+  RescriptRelayReact.loadQuery(
     environment,
     node,
     variables->Internal.convertVariables,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce `RescriptRelayMode` (Default | NonReact) to config and conditionally emit React-specific ReScript codegen; change generated `load` to use `RescriptRelayReact.loadQuery`.
> 
> - **Config**:
>   - Add `RescriptRelayMode` (Default | NonReact) to `ProjectConfig`, `ConfigFileProject`, and single-project config, with defaults and JSON schema/serde wiring; export via `relay-config`.
> - **ReScript Codegen**:
>   - Use `RescriptRelayReact.loadQuery` in generated `load` and in `get_load_fn_code` (`rescript_utils.rs`).
>   - Conditionally emit `get_load_query_code` for queries only when not preloadable and `rescript_relay_mode != NonReact`.
> - **Generated Artifacts/Tests**:
>   - Update all affected `__generated__/*.res` files to call `RescriptRelayReact.loadQuery`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e886d99f2a1675af0027d011cba17b2828d55220. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->