### PR TITLE
@exhaustive on inline fragment

### DIFF
--- a/compiler/crates/relay-schema/src/relay-extensions.graphql
+++ b/compiler/crates/relay-schema/src/relay-extensions.graphql
@@ -358,14 +358,14 @@ directive @codesplit on FRAGMENT_SPREAD
 
 Marks a field as exhaustive.
 """
-directive @exhaustive(ignore: [String!], disabled: Boolean) on FIELD | FRAGMENT_DEFINITION
+directive @exhaustive(ignore: [String!], disabled: Boolean) on FIELD | FRAGMENT_DEFINITION | INLINE_FRAGMENT
 
 """
 (RescriptRelay only)
 
 Opt out of automatic exhaustive validation for a field or fragment.
 """
-directive @nonExhaustive on FIELD | FRAGMENT_DEFINITION
+directive @nonExhaustive on FIELD | FRAGMENT_DEFINITION | INLINE_FRAGMENT
 
 """
 (Relay Only)

--- a/compiler/crates/relay-transforms/src/errors.rs
+++ b/compiler/crates/relay-transforms/src/errors.rs
@@ -241,7 +241,15 @@ pub enum ValidationMessage {
     },
 
     #[error(
-        "The @exhaustive directive can only be applied to fields or fragment definitions returning union or interface types."
+        "Inline fragment marked with @exhaustive is missing selection for {type_description}: {member_names}."
+    )]
+    MissingExhaustiveMembersOnInlineFragment {
+        member_names: String,
+        type_description: &'static str,
+    },
+
+    #[error(
+        "The @exhaustive directive can only be applied to fields, inline fragments, or fragment definitions returning union or interface types."
     )]
     ExhaustiveDirectiveOnNonUnionOrInterfaceField,
 }

--- a/compiler/crates/relay-transforms/src/validations/validate_exhaustive_directive.rs
+++ b/compiler/crates/relay-transforms/src/validations/validate_exhaustive_directive.rs
@@ -380,20 +380,6 @@ impl<'schema, 'program, 'pc> ExhaustiveDirectiveValidator<'schema, 'program, 'pc
             .named(*NON_EXHAUSTIVE_DIRECTIVE_NAME)
             .is_some();
 
-        if let Some(directive) = inline_fragment.directives.named(*EXHAUSTIVE_DIRECTIVE_NAME) {
-            has_directive = true;
-            let (parsed_ignored, parsed_disabled) =
-                Self::parse_exhaustive_directive_args(directive);
-            ignored = parsed_ignored;
-            disabled = parsed_disabled;
-        } else if has_non_exhaustive {
-            return;
-        }
-
-        if !has_directive || disabled {
-            return;
-        }
-
         // Determine the type against which to validate coverage.
         let target_type = if let Some(type_condition) = inline_fragment.type_condition {
             type_condition
@@ -403,6 +389,22 @@ impl<'schema, 'program, 'pc> ExhaustiveDirectiveValidator<'schema, 'program, 'pc
             // Should not happen in practice, but bail out safely.
             return;
         };
+
+        if let Some(directive) = inline_fragment.directives.named(*EXHAUSTIVE_DIRECTIVE_NAME) {
+            has_directive = true;
+            let (parsed_ignored, parsed_disabled) =
+                Self::parse_exhaustive_directive_args(directive);
+            ignored = parsed_ignored;
+            disabled = parsed_disabled;
+        } else if has_non_exhaustive {
+            return;
+        } else if self.type_is_auto_exhaustive(target_type) {
+            has_directive = true;
+        }
+
+        if !has_directive || disabled {
+            return;
+        }
 
         let (missing_members, type_description) = match target_type {
             Type::Union(id) => (

--- a/compiler/crates/relay-transforms/src/validations/validate_exhaustive_directive.rs
+++ b/compiler/crates/relay-transforms/src/validations/validate_exhaustive_directive.rs
@@ -7,6 +7,7 @@ use common::DirectiveName;
 use common::NamedItem;
 use graphql_ir::ConstantValue;
 use graphql_ir::FragmentDefinition;
+use graphql_ir::InlineFragment;
 use graphql_ir::LinkedField;
 use graphql_ir::OperationDefinition;
 use graphql_ir::Program;
@@ -55,6 +56,7 @@ struct ExhaustiveDirectiveValidator<'schema, 'program, 'pc> {
     program: &'program Program,
     project_config: &'pc ProjectConfig,
     is_mutation: bool,
+    parent_type: Option<Type>,
     auto_exhaustive_types: std::collections::HashSet<StringKey>,
     errors: Vec<Diagnostic>,
 }
@@ -70,6 +72,7 @@ impl<'schema, 'program, 'pc> ExhaustiveDirectiveValidator<'schema, 'program, 'pc
             program,
             project_config,
             is_mutation: false,
+            parent_type: None,
             auto_exhaustive_types: project_config
                 .auto_exhaustive_types
                 .iter()
@@ -342,6 +345,104 @@ impl<'schema, 'program, 'pc> ExhaustiveDirectiveValidator<'schema, 'program, 'pc
         false
     }
 
+    fn has_selection_for_object_in_inline_fragment(
+        &self,
+        inline_fragment: &InlineFragment,
+        object_id: ObjectID,
+    ) -> bool {
+        let obj_type = Type::Object(object_id);
+        for selection in &inline_fragment.selections {
+            match selection {
+                Selection::InlineFragment(frag) => {
+                    if frag.type_condition == Some(obj_type) {
+                        return true;
+                    }
+                }
+                Selection::FragmentSpread(frag_spread) => {
+                    if let Some(frag_def) = self.program.fragment(frag_spread.fragment.item) {
+                        if frag_def.type_condition == obj_type {
+                            return true;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        false
+    }
+
+    fn validate_exhaustive_inline_fragment(&mut self, inline_fragment: &InlineFragment) {
+        let mut ignored = std::collections::HashSet::new();
+        let mut disabled = false;
+        let mut has_directive = false;
+        let has_non_exhaustive = inline_fragment
+            .directives
+            .named(*NON_EXHAUSTIVE_DIRECTIVE_NAME)
+            .is_some();
+
+        if let Some(directive) = inline_fragment.directives.named(*EXHAUSTIVE_DIRECTIVE_NAME) {
+            has_directive = true;
+            let (parsed_ignored, parsed_disabled) =
+                Self::parse_exhaustive_directive_args(directive);
+            ignored = parsed_ignored;
+            disabled = parsed_disabled;
+        } else if has_non_exhaustive {
+            return;
+        }
+
+        if !has_directive || disabled {
+            return;
+        }
+
+        // Determine the type against which to validate coverage.
+        let target_type = if let Some(type_condition) = inline_fragment.type_condition {
+            type_condition
+        } else if let Some(parent_type) = self.parent_type {
+            parent_type
+        } else {
+            // Should not happen in practice, but bail out safely.
+            return;
+        };
+
+        let (missing_members, type_description) = match target_type {
+            Type::Union(id) => (
+                self.check_exhaustive_union_coverage(id, &ignored, |object_id| {
+                    self.has_selection_for_object_in_inline_fragment(inline_fragment, object_id)
+                }),
+                "union members",
+            ),
+            Type::Interface(id) => (
+                self.check_exhaustive_interface_coverage(id, &ignored, |object_id| {
+                    self.has_selection_for_object_in_inline_fragment(inline_fragment, object_id)
+                }),
+                "interface implementations",
+            ),
+            _ => {
+                self.errors.push(Diagnostic::error(
+                    ValidationMessage::ExhaustiveDirectiveOnNonUnionOrInterfaceField,
+                    inline_fragment.spread_location,
+                ));
+                return;
+            }
+        };
+
+        if !missing_members.is_empty() {
+            let member_names = missing_members
+                .iter()
+                .map(|name| format!("'{}'", name))
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            self.errors.push(Diagnostic::error(
+                ValidationMessage::MissingExhaustiveMembersOnInlineFragment {
+                    member_names,
+                    type_description,
+                },
+                inline_fragment.spread_location,
+            ));
+        }
+    }
+
     fn field_is_top_level_mutation(&self, field: &LinkedField) -> bool {
         match (
             self.schema.mutation_type(),
@@ -380,13 +481,22 @@ impl Validator for ExhaustiveDirectiveValidator<'_, '_, '_> {
 
     fn validate_linked_field(&mut self, field: &LinkedField) -> DiagnosticsResult<()> {
         self.validate_exhaustive(field);
-        self.default_validate_linked_field(field)
+        // Set parent type to the field's return type while validating children.
+        let prev_parent_type = self.parent_type;
+        let field_def = self.schema.field(field.definition.item);
+        self.parent_type = Some(field_def.type_.inner());
+        let res = self.default_validate_linked_field(field);
+        self.parent_type = prev_parent_type;
+        res
     }
 
     fn validate_operation(&mut self, operation: &OperationDefinition) -> DiagnosticsResult<()> {
         let prev = self.is_mutation;
         self.is_mutation = operation.is_mutation();
+        let prev_parent_type = self.parent_type;
+        self.parent_type = Some(operation.type_);
         let result = self.default_validate_operation(operation);
+        self.parent_type = prev_parent_type;
         self.is_mutation = prev;
         result
     }
@@ -403,6 +513,22 @@ impl Validator for ExhaustiveDirectiveValidator<'_, '_, '_> {
 
     fn validate_fragment(&mut self, fragment: &FragmentDefinition) -> DiagnosticsResult<()> {
         self.validate_exhaustive_fragment(fragment);
-        self.default_validate_fragment(fragment)
+        let prev_parent_type = self.parent_type;
+        self.parent_type = Some(fragment.type_condition);
+        let res = self.default_validate_fragment(fragment);
+        self.parent_type = prev_parent_type;
+        res
+    }
+
+    fn validate_inline_fragment(&mut self, fragment: &InlineFragment) -> DiagnosticsResult<()> {
+        self.validate_exhaustive_inline_fragment(fragment);
+        // Update parent type context for nested selections within this inline fragment.
+        let prev_parent_type = self.parent_type;
+        if let Some(type_condition) = fragment.type_condition {
+            self.parent_type = Some(type_condition);
+        }
+        let res = self.default_validate_inline_fragment(fragment);
+        self.parent_type = prev_parent_type;
+        res
     }
 }

--- a/compiler/crates/relay-transforms/tests/validate_exhaustive_directive.rs
+++ b/compiler/crates/relay-transforms/tests/validate_exhaustive_directive.rs
@@ -13,7 +13,9 @@ use relay_transforms::validate_exhaustive_directive;
 
 pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| {
-        let auto_exhaustive_types = if fixture.file_name.contains("auto-type") {
+        let auto_exhaustive_types = if fixture.file_name.contains("auto-type")
+            || fixture.file_name.contains("inline-fragment-auto-type")
+        {
             vec!["UserNameRenderer".intern()]
         } else {
             vec![]

--- a/compiler/crates/relay-transforms/tests/validate_exhaustive_directive/fixtures/directive-on-non-union.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/validate_exhaustive_directive/fixtures/directive-on-non-union.invalid.expected
@@ -4,7 +4,7 @@ fragment DirectiveOnNonUnion on User {
   name @exhaustive
 }
 ==================================== ERROR ====================================
-✖︎ The @exhaustive directive can only be applied to fields or fragment definitions returning union or interface types.
+✖︎ The @exhaustive directive can only be applied to fields, inline fragments, or fragment definitions returning union or interface types.
 
   directive-on-non-union.invalid.graphql:3:3
     2 │ fragment DirectiveOnNonUnion on User {

--- a/compiler/crates/relay-transforms/tests/validate_exhaustive_directive/fixtures/inline-fragment-all-members-valid.expected
+++ b/compiler/crates/relay-transforms/tests/validate_exhaustive_directive/fixtures/inline-fragment-all-members-valid.expected
@@ -1,0 +1,26 @@
+==================================== INPUT ====================================
+fragment InlineFragmentAllMembersValid on User {
+  nameRenderer {
+    ... @exhaustive {
+      ... on PlainUserNameRenderer { __typename }
+      ... on MarkdownUserNameRenderer { __typename }
+      ... on CustomNameRenderer { __typename }
+    }
+  }
+}
+==================================== OUTPUT ===================================
+fragment InlineFragmentAllMembersValid on User {
+  nameRenderer {
+    ... @exhaustive {
+      ... on PlainUserNameRenderer {
+        __typename
+      }
+      ... on MarkdownUserNameRenderer {
+        __typename
+      }
+      ... on CustomNameRenderer {
+        __typename
+      }
+    }
+  }
+}

--- a/compiler/crates/relay-transforms/tests/validate_exhaustive_directive/fixtures/inline-fragment-all-members-valid.graphql
+++ b/compiler/crates/relay-transforms/tests/validate_exhaustive_directive/fixtures/inline-fragment-all-members-valid.graphql
@@ -1,0 +1,10 @@
+fragment InlineFragmentAllMembersValid on User {
+  nameRenderer {
+    ... @exhaustive {
+      ... on PlainUserNameRenderer { __typename }
+      ... on MarkdownUserNameRenderer { __typename }
+      ... on CustomNameRenderer { __typename }
+    }
+  }
+}
+

--- a/compiler/crates/relay-transforms/tests/validate_exhaustive_directive/fixtures/inline-fragment-auto-type-missing.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/validate_exhaustive_directive/fixtures/inline-fragment-auto-type-missing.invalid.expected
@@ -1,0 +1,20 @@
+==================================== INPUT ====================================
+#expected-to-throw
+query InlineFragmentAutoTypeMissing {
+  me {
+    nameRenderer @nonExhaustive {
+      ... {
+        ... on PlainUserNameRenderer { __typename }
+        ... on MarkdownUserNameRenderer { __typename }
+      }
+    }
+  }
+}
+==================================== ERROR ====================================
+✖︎ Inline fragment marked with @exhaustive is missing selection for union members: 'CustomNameRenderer'.
+
+  inline-fragment-auto-type-missing.invalid.graphql:5:7
+    4 │     nameRenderer @nonExhaustive {
+    5 │       ... {
+      │       ^^^
+    6 │         ... on PlainUserNameRenderer { __typename }

--- a/compiler/crates/relay-transforms/tests/validate_exhaustive_directive/fixtures/inline-fragment-auto-type-missing.invalid.graphql
+++ b/compiler/crates/relay-transforms/tests/validate_exhaustive_directive/fixtures/inline-fragment-auto-type-missing.invalid.graphql
@@ -1,0 +1,11 @@
+#expected-to-throw
+query InlineFragmentAutoTypeMissing {
+  me {
+    nameRenderer @nonExhaustive {
+      ... {
+        ... on PlainUserNameRenderer { __typename }
+        ... on MarkdownUserNameRenderer { __typename }
+      }
+    }
+  }
+}

--- a/compiler/crates/relay-transforms/tests/validate_exhaustive_directive/fixtures/inline-fragment-missing-member.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/validate_exhaustive_directive/fixtures/inline-fragment-missing-member.invalid.expected
@@ -1,0 +1,18 @@
+==================================== INPUT ====================================
+#expected-to-throw
+fragment InlineFragmentMissingMember on User {
+  nameRenderer {
+    ... @exhaustive {
+      ... on PlainUserNameRenderer { __typename }
+      ... on MarkdownUserNameRenderer { __typename }
+    }
+  }
+}
+==================================== ERROR ====================================
+✖︎ Inline fragment marked with @exhaustive is missing selection for union members: 'CustomNameRenderer'.
+
+  inline-fragment-missing-member.invalid.graphql:4:5
+    3 │   nameRenderer {
+    4 │     ... @exhaustive {
+      │     ^^^
+    5 │       ... on PlainUserNameRenderer { __typename }

--- a/compiler/crates/relay-transforms/tests/validate_exhaustive_directive/fixtures/inline-fragment-missing-member.invalid.graphql
+++ b/compiler/crates/relay-transforms/tests/validate_exhaustive_directive/fixtures/inline-fragment-missing-member.invalid.graphql
@@ -1,0 +1,10 @@
+#expected-to-throw
+fragment InlineFragmentMissingMember on User {
+  nameRenderer {
+    ... @exhaustive {
+      ... on PlainUserNameRenderer { __typename }
+      ... on MarkdownUserNameRenderer { __typename }
+    }
+  }
+}
+

--- a/compiler/crates/relay-transforms/tests/validate_exhaustive_directive/fixtures/inline-fragment-with-alias-exhaustive.expected
+++ b/compiler/crates/relay-transforms/tests/validate_exhaustive_directive/fixtures/inline-fragment-with-alias-exhaustive.expected
@@ -1,0 +1,30 @@
+==================================== INPUT ====================================
+query InlineFragmentWithAliasExhaustive {
+  me {
+    nameRenderer {
+      ... @alias(as: "widget") @exhaustive {
+        ... on PlainUserNameRenderer { __typename }
+        ... on MarkdownUserNameRenderer { __typename }
+        ... on CustomNameRenderer { __typename }
+      }
+    }
+  }
+}
+==================================== OUTPUT ===================================
+query InlineFragmentWithAliasExhaustive {
+  me {
+    nameRenderer {
+      ... @alias(as: "widget") @exhaustive {
+        ... on PlainUserNameRenderer {
+          __typename
+        }
+        ... on MarkdownUserNameRenderer {
+          __typename
+        }
+        ... on CustomNameRenderer {
+          __typename
+        }
+      }
+    }
+  }
+}

--- a/compiler/crates/relay-transforms/tests/validate_exhaustive_directive/fixtures/inline-fragment-with-alias-exhaustive.graphql
+++ b/compiler/crates/relay-transforms/tests/validate_exhaustive_directive/fixtures/inline-fragment-with-alias-exhaustive.graphql
@@ -1,0 +1,12 @@
+query InlineFragmentWithAliasExhaustive {
+  me {
+    nameRenderer {
+      ... @alias(as: "widget") @exhaustive {
+        ... on PlainUserNameRenderer { __typename }
+        ... on MarkdownUserNameRenderer { __typename }
+        ... on CustomNameRenderer { __typename }
+      }
+    }
+  }
+}
+

--- a/compiler/crates/relay-transforms/tests/validate_exhaustive_directive_test.rs
+++ b/compiler/crates/relay-transforms/tests/validate_exhaustive_directive_test.rs
@@ -190,6 +190,25 @@ async fn interface_all_members_valid() {
 }
 
 #[tokio::test]
+async fn inline_fragment_with_alias_exhaustive() {
+    let input = include_str!(
+        "validate_exhaustive_directive/fixtures/inline-fragment-with-alias-exhaustive.graphql"
+    );
+    let expected = include_str!(
+        "validate_exhaustive_directive/fixtures/inline-fragment-with-alias-exhaustive.expected"
+    );
+    test_fixture(
+        transform_fixture,
+        file!(),
+        "inline-fragment-with-alias-exhaustive.graphql",
+        "validate_exhaustive_directive/fixtures/inline-fragment-with-alias-exhaustive.expected",
+        input,
+        expected,
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn interface_missing_member() {
     let input = include_str!(
         "validate_exhaustive_directive/fixtures/interface-missing-member.invalid.graphql"
@@ -240,6 +259,25 @@ async fn inline_fragment_missing_member() {
         file!(),
         "inline-fragment-missing-member.invalid.graphql",
         "validate_exhaustive_directive/fixtures/inline-fragment-missing-member.invalid.expected",
+        input,
+        expected,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn inline_fragment_auto_type_missing() {
+    let input = include_str!(
+        "validate_exhaustive_directive/fixtures/inline-fragment-auto-type-missing.invalid.graphql"
+    );
+    let expected = include_str!(
+        "validate_exhaustive_directive/fixtures/inline-fragment-auto-type-missing.invalid.expected"
+    );
+    test_fixture(
+        transform_fixture,
+        file!(),
+        "inline-fragment-auto-type-missing.invalid.graphql",
+        "validate_exhaustive_directive/fixtures/inline-fragment-auto-type-missing.invalid.expected",
         input,
         expected,
     )

--- a/compiler/crates/relay-transforms/tests/validate_exhaustive_directive_test.rs
+++ b/compiler/crates/relay-transforms/tests/validate_exhaustive_directive_test.rs
@@ -207,3 +207,41 @@ async fn interface_missing_member() {
     )
     .await;
 }
+
+#[tokio::test]
+async fn inline_fragment_all_members_valid() {
+    let input = include_str!(
+        "validate_exhaustive_directive/fixtures/inline-fragment-all-members-valid.graphql"
+    );
+    let expected = include_str!(
+        "validate_exhaustive_directive/fixtures/inline-fragment-all-members-valid.expected"
+    );
+    test_fixture(
+        transform_fixture,
+        file!(),
+        "inline-fragment-all-members-valid.graphql",
+        "validate_exhaustive_directive/fixtures/inline-fragment-all-members-valid.expected",
+        input,
+        expected,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn inline_fragment_missing_member() {
+    let input = include_str!(
+        "validate_exhaustive_directive/fixtures/inline-fragment-missing-member.invalid.graphql"
+    );
+    let expected = include_str!(
+        "validate_exhaustive_directive/fixtures/inline-fragment-missing-member.invalid.expected"
+    );
+    test_fixture(
+        transform_fixture,
+        file!(),
+        "inline-fragment-missing-member.invalid.graphql",
+        "validate_exhaustive_directive/fixtures/inline-fragment-missing-member.invalid.expected",
+        input,
+        expected,
+    )
+    .await;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enable @exhaustive/@nonExhaustive on inline fragments with full validation, new error messaging, parent-type tracking, and comprehensive tests.
> 
> - **Schema**:
>   - Extend `@exhaustive` and `@nonExhaustive` directives to `INLINE_FRAGMENT` in `compiler/crates/relay-schema/src/relay-extensions.graphql`.
> - **Validation**:
>   - Add inline fragment exhaustive validation (`validate_exhaustive_inline_fragment`) with selection checks and `parent_type` context propagation across operations, fields, fragments, and inline fragments.
>   - Introduce `MissingExhaustiveMembersOnInlineFragment` error and broaden non-union/interface error message to include inline fragments.
>   - Helpers to detect object coverage within inline fragments.
> - **Tests**:
>   - New fixtures for inline fragment exhaustive coverage (valid, missing member, alias, auto-type missing) and hook into auto-exhaustive types for inline-fragment cases.
>   - Update expected message for directive-on-non-union to mention inline fragments.
>   - Register new tests in `validate_exhaustive_directive_test.rs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1ac3d523dca9057c8d55edce966911fcb9565a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->