### PR TITLE
Generate Test module from relay compiler

### DIFF
--- a/compiler/crates/relay-typegen/src/rescript.rs
+++ b/compiler/crates/relay-typegen/src/rescript.rs
@@ -8,6 +8,7 @@
 use std::fmt::Result;
 use std::fmt::Write;
 
+use common::NamedItem;
 use common::rescript_utils::get_module_name_from_file_path;
 use fnv::FnvHashMap;
 use fnv::FnvHashSet;
@@ -18,6 +19,7 @@ use intern::string_key::Intern;
 use itertools::Itertools;
 use log::debug;
 use log::warn;
+use relay_transforms::INLINE_DIRECTIVE_NAME;
 
 use crate::rescript_ast::*;
 use crate::rescript_relay_visitor::RescriptRelayFragmentDirective;
@@ -2836,6 +2838,10 @@ impl Writer for ReScriptPrinter {
                     .unwrap();
                 } else {
                     let plural = is_plural(fragment_definition);
+                    let inline = fragment_definition
+                        .directives
+                        .named(*INLINE_DIRECTIVE_NAME)
+                        .is_some();
 
                     write_indentation(&mut generated_types, indentation).unwrap();
                     writeln!(
@@ -2852,6 +2858,19 @@ impl Writer for ReScriptPrinter {
                         if plural { ">" } else { "" }
                     )
                     .unwrap();
+
+                    if !inline {
+                        write_indentation(&mut generated_types, indentation).unwrap();
+                        writeln!(
+                            generated_types,
+                            "module Test = {{\n  let fromData = (data: Types.fragment): {}RescriptRelay.fragmentRefs<[> | #{}]>{} =>\n    RescriptRelay_TestFragmentRef.make(\"{}\", data)\n}}\n",
+                            if plural { "array<" } else { "" },
+                            fragment_definition.name.item,
+                            if plural { ">" } else { "" },
+                            fragment_definition.name.item
+                        )
+                        .unwrap();
+                    }
                 }
             }
             DefinitionType::Operation(_) => {

--- a/compiler/test-project-res-preloadable/src/__generated__/TestPreloadedQuery_user_graphql.res
+++ b/compiler/test-project-res-preloadable/src/__generated__/TestPreloadedQuery_user_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestPreloadedQuery_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestPreloadedQuery_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestPreloadedQuery_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res-preloadable/src/__generated__/UserAvatar_user_graphql.res
+++ b/compiler/test-project-res-preloadable/src/__generated__/UserAvatar_user_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #UserAvatar_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #UserAvatar_user]> =>
+    RescriptRelay_TestFragmentRef.make("UserAvatar_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res-preloadable/src/__generated__/UserName_user_graphql.res
+++ b/compiler/test-project-res-preloadable/src/__generated__/UserName_user_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #UserName_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #UserName_user]> =>
+    RescriptRelay_TestFragmentRef.make("UserName_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/FriendComponent2_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/FriendComponent2_user_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #FriendComponent2_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #FriendComponent2_user]> =>
+    RescriptRelay_TestFragmentRef.make("FriendComponent2_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/FriendComponentSkip_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/FriendComponentSkip_user_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #FriendComponentSkip_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #FriendComponentSkip_user]> =>
+    RescriptRelay_TestFragmentRef.make("FriendComponentSkip_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/FriendComponent_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/FriendComponent_user_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #FriendComponent_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #FriendComponent_user]> =>
+    RescriptRelay_TestFragmentRef.make("FriendComponent_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/GroupAvatar_group_graphql.res
+++ b/compiler/test-project-res/src/__generated__/GroupAvatar_group_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #GroupAvatar_group]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #GroupAvatar_group]> =>
+    RescriptRelay_TestFragmentRef.make("GroupAvatar_group", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/LocalUser____relay_model_instance_graphql.res
+++ b/compiler/test-project-res/src/__generated__/LocalUser____relay_model_instance_graphql.res
@@ -29,6 +29,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #LocalUser____relay_model_instance]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #LocalUser____relay_model_instance]> =>
+    RescriptRelay_TestFragmentRef.make("LocalUser____relay_model_instance", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/LocalUser__id_graphql.res
+++ b/compiler/test-project-res/src/__generated__/LocalUser__id_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #LocalUser__id]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #LocalUser__id]> =>
+    RescriptRelay_TestFragmentRef.make("LocalUser__id", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/RichContent_content_graphql.res
+++ b/compiler/test-project-res/src/__generated__/RichContent_content_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #RichContent_content]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #RichContent_content]> =>
+    RescriptRelay_TestFragmentRef.make("RichContent_content", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestAliasedFragments_container_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestAliasedFragments_container_graphql.res
@@ -33,6 +33,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestAliasedFragments_container]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestAliasedFragments_container]> =>
+    RescriptRelay_TestFragmentRef.make("TestAliasedFragments_container", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestAliasedFragments_one_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestAliasedFragments_one_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestAliasedFragments_one]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestAliasedFragments_one]> =>
+    RescriptRelay_TestFragmentRef.make("TestAliasedFragments_one", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestAliasedFragments_required_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestAliasedFragments_required_graphql.res
@@ -36,6 +36,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestAliasedFragments_required]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestAliasedFragments_required]> =>
+    RescriptRelay_TestFragmentRef.make("TestAliasedFragments_required", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestAliasedFragments_two_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestAliasedFragments_two_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestAliasedFragments_two]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestAliasedFragments_two]> =>
+    RescriptRelay_TestFragmentRef.make("TestAliasedFragments_two", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestCatchAndFriendsUserPlural_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestCatchAndFriendsUserPlural_user_graphql.res
@@ -34,6 +34,11 @@ type fragmentRef
 external getFragmentRef:
   array<RescriptRelay.fragmentRefs<[> | #TestCatchAndFriendsUserPlural_user]>> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): array<RescriptRelay.fragmentRefs<[> | #TestCatchAndFriendsUserPlural_user]>> =>
+    RescriptRelay_TestFragmentRef.make("TestCatchAndFriendsUserPlural_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestCatchAndFriendsUser_member_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestCatchAndFriendsUser_member_graphql.res
@@ -48,6 +48,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestCatchAndFriendsUser_member]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestCatchAndFriendsUser_member]> =>
+    RescriptRelay_TestFragmentRef.make("TestCatchAndFriendsUser_member", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestCatchAndFriendsUser_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestCatchAndFriendsUser_user_graphql.res
@@ -34,6 +34,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestCatchAndFriendsUser_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestCatchAndFriendsUser_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestCatchAndFriendsUser_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestConnectionsPlural_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestConnectionsPlural_user_graphql.res
@@ -41,6 +41,11 @@ type fragmentRef
 external getFragmentRef:
   array<RescriptRelay.fragmentRefs<[> | #TestConnectionsPlural_user]>> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): array<RescriptRelay.fragmentRefs<[> | #TestConnectionsPlural_user]>> =>
+    RescriptRelay_TestFragmentRef.make("TestConnectionsPlural_user", data)
+}
+
 @live
 @inline
 let connectionKey = "TestConnections_user_friendsConnection"

--- a/compiler/test-project-res/src/__generated__/TestConnectionsUnionPlural_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestConnectionsUnionPlural_user_graphql.res
@@ -55,6 +55,11 @@ type fragmentRef
 external getFragmentRef:
   array<RescriptRelay.fragmentRefs<[> | #TestConnectionsUnionPlural_user]>> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): array<RescriptRelay.fragmentRefs<[> | #TestConnectionsUnionPlural_user]>> =>
+    RescriptRelay_TestFragmentRef.make("TestConnectionsUnionPlural_user", data)
+}
+
 @live
 @inline
 let connectionKey = "TestConnections_user_friendsConnection"

--- a/compiler/test-project-res/src/__generated__/TestConnectionsUnion_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestConnectionsUnion_user_graphql.res
@@ -54,6 +54,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestConnectionsUnion_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestConnectionsUnion_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestConnectionsUnion_user", data)
+}
+
 @live
 @inline
 let connectionKey = "TestConnections_user_friendsConnection"

--- a/compiler/test-project-res/src/__generated__/TestConnectionsWithConstantValues_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestConnectionsWithConstantValues_user_graphql.res
@@ -40,6 +40,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestConnectionsWithConstantValues_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestConnectionsWithConstantValues_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestConnectionsWithConstantValues_user", data)
+}
+
 @live
 @inline
 let connectionKey = "TestConnectionsWithonstantValues_user_friendsConnection"

--- a/compiler/test-project-res/src/__generated__/TestConnectionsWithEmptyFilters_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestConnectionsWithEmptyFilters_user_graphql.res
@@ -40,6 +40,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestConnectionsWithEmptyFilters_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestConnectionsWithEmptyFilters_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestConnectionsWithEmptyFilters_user", data)
+}
+
 @live
 @inline
 let connectionKey = "TestConnectionsWithEmptyFilters_user_friendsConnection"

--- a/compiler/test-project-res/src/__generated__/TestConnectionsWithFilters_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestConnectionsWithFilters_user_graphql.res
@@ -40,6 +40,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestConnectionsWithFilters_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestConnectionsWithFilters_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestConnectionsWithFilters_user", data)
+}
+
 @live
 @inline
 let connectionKey = "TestConnectionsWithFilters_user_friendsConnection"

--- a/compiler/test-project-res/src/__generated__/TestConnections_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestConnections_user_graphql.res
@@ -40,6 +40,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestConnections_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestConnections_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestConnections_user", data)
+}
+
 @live
 @inline
 let connectionKey = "TestConnections_user_friendsConnection"

--- a/compiler/test-project-res/src/__generated__/TestFragment_allowUnsafeEnum_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestFragment_allowUnsafeEnum_graphql.res
@@ -33,6 +33,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestFragment_allowUnsafeEnum]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestFragment_allowUnsafeEnum]> =>
+    RescriptRelay_TestFragmentRef.make("TestFragment_allowUnsafeEnum", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestFragment_ignoreUnused_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestFragment_ignoreUnused_graphql.res
@@ -33,6 +33,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestFragment_ignoreUnused]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestFragment_ignoreUnused]> =>
+    RescriptRelay_TestFragmentRef.make("TestFragment_ignoreUnused", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestFragment_plural_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestFragment_plural_user_graphql.res
@@ -34,6 +34,11 @@ type fragmentRef
 external getFragmentRef:
   array<RescriptRelay.fragmentRefs<[> | #TestFragment_plural_user]>> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): array<RescriptRelay.fragmentRefs<[> | #TestFragment_plural_user]>> =>
+    RescriptRelay_TestFragmentRef.make("TestFragment_plural_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestFragment_requiredPlural_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestFragment_requiredPlural_user_graphql.res
@@ -34,6 +34,11 @@ type fragmentRef
 external getFragmentRef:
   array<RescriptRelay.fragmentRefs<[> | #TestFragment_requiredPlural_user]>> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): array<RescriptRelay.fragmentRefs<[> | #TestFragment_requiredPlural_user]>> =>
+    RescriptRelay_TestFragmentRef.make("TestFragment_requiredPlural_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestFragment_requiredUnionPlural_member_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestFragment_requiredUnionPlural_member_graphql.res
@@ -50,6 +50,11 @@ type fragmentRef
 external getFragmentRef:
   array<RescriptRelay.fragmentRefs<[> | #TestFragment_requiredUnionPlural_member]>> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): array<RescriptRelay.fragmentRefs<[> | #TestFragment_requiredUnionPlural_member]>> =>
+    RescriptRelay_TestFragmentRef.make("TestFragment_requiredUnionPlural_member", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestFragment_requiredUnion_member_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestFragment_requiredUnion_member_graphql.res
@@ -50,6 +50,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestFragment_requiredUnion_member]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestFragment_requiredUnion_member]> =>
+    RescriptRelay_TestFragmentRef.make("TestFragment_requiredUnion_member", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestFragment_required_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestFragment_required_user_graphql.res
@@ -34,6 +34,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestFragment_required_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestFragment_required_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestFragment_required_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestFragment_sub_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestFragment_sub_user_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestFragment_sub_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestFragment_sub_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestFragment_sub_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestFragment_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestFragment_user_graphql.res
@@ -34,6 +34,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestFragment_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestFragment_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestFragment_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestInterfaces_hasName_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestInterfaces_hasName_graphql.res
@@ -52,6 +52,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestInterfaces_hasName]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestInterfaces_hasName]> =>
+    RescriptRelay_TestFragmentRef.make("TestInterfaces_hasName", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestLocalPayload_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestLocalPayload_user_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestLocalPayload_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestLocalPayload_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestLocalPayload_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestMutation_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestMutation_user_graphql.res
@@ -54,6 +54,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestMutation_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestMutation_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestMutation_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestPaginationInNode_query_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestPaginationInNode_query_graphql.res
@@ -42,6 +42,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestPaginationInNode_query]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestPaginationInNode_query]> =>
+    RescriptRelay_TestFragmentRef.make("TestPaginationInNode_query", data)
+}
+
 @live
 @inline
 let connectionKey = "TestPaginationInNode_friendsConnection"

--- a/compiler/test-project-res/src/__generated__/TestPaginationInNode_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestPaginationInNode_user_graphql.res
@@ -36,6 +36,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestPaginationInNode_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestPaginationInNode_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestPaginationInNode_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestPaginationUnion_query_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestPaginationUnion_query_graphql.res
@@ -69,6 +69,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestPaginationUnion_query]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestPaginationUnion_query]> =>
+    RescriptRelay_TestFragmentRef.make("TestPaginationUnion_query", data)
+}
+
 @live
 @inline
 let connectionKey = "TestPaginationUnion_query_members"

--- a/compiler/test-project-res/src/__generated__/TestPaginationUnion_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestPaginationUnion_user_graphql.res
@@ -35,6 +35,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestPaginationUnion_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestPaginationUnion_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestPaginationUnion_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestProvidedVariables_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestProvidedVariables_user_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestProvidedVariables_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestProvidedVariables_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestProvidedVariables_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestRefetchingInNode_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestRefetchingInNode_user_graphql.res
@@ -37,6 +37,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestRefetchingInNode_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestRefetchingInNode_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestRefetchingInNode_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestRefetchingNoArgs_query_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestRefetchingNoArgs_query_graphql.res
@@ -34,6 +34,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestRefetchingNoArgs_query]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestRefetchingNoArgs_query]> =>
+    RescriptRelay_TestFragmentRef.make("TestRefetchingNoArgs_query", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestRefetching_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestRefetching_user_graphql.res
@@ -37,6 +37,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestRefetching_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestRefetching_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestRefetching_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestRelayResolverMultiFancyGreeting_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestRelayResolverMultiFancyGreeting_graphql.res
@@ -31,6 +31,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestRelayResolverMultiFancyGreeting]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestRelayResolverMultiFancyGreeting]> =>
+    RescriptRelay_TestFragmentRef.make("TestRelayResolverMultiFancyGreeting", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestRelayResolver_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestRelayResolver_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestRelayResolver]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestRelayResolver]> =>
+    RescriptRelay_TestFragmentRef.make("TestRelayResolver", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestSchemaExtensionsQuery_fragment_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestSchemaExtensionsQuery_fragment_graphql.res
@@ -46,6 +46,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestSchemaExtensionsQuery_fragment]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestSchemaExtensionsQuery_fragment]> =>
+    RescriptRelay_TestFragmentRef.make("TestSchemaExtensionsQuery_fragment", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestSubscription_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestSubscription_user_graphql.res
@@ -34,6 +34,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestSubscription_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestSubscription_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestSubscription_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestUnionFragmentUser_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestUnionFragmentUser_user_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestUnionFragmentUser_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestUnionFragmentUser_user]> =>
+    RescriptRelay_TestFragmentRef.make("TestUnionFragmentUser_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestUnionFragment_member_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestUnionFragment_member_graphql.res
@@ -49,6 +49,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestUnionFragment_member]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestUnionFragment_member]> =>
+    RescriptRelay_TestFragmentRef.make("TestUnionFragment_member", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestUnionFragment_plural_member_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestUnionFragment_plural_member_graphql.res
@@ -50,6 +50,11 @@ type fragmentRef
 external getFragmentRef:
   array<RescriptRelay.fragmentRefs<[> | #TestUnionFragment_plural_member]>> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): array<RescriptRelay.fragmentRefs<[> | #TestUnionFragment_plural_member]>> =>
+    RescriptRelay_TestFragmentRef.make("TestUnionFragment_plural_member", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/TestUpdatableFragments_query_graphql.res
+++ b/compiler/test-project-res/src/__generated__/TestUpdatableFragments_query_graphql.res
@@ -36,6 +36,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #TestUpdatableFragments_query]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #TestUpdatableFragments_query]> =>
+    RescriptRelay_TestFragmentRef.make("TestUpdatableFragments_query", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/UserAvatar_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/UserAvatar_user_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #UserAvatar_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #UserAvatar_user]> =>
+    RescriptRelay_TestFragmentRef.make("UserAvatar_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/UserMeta____relay_model_instance_graphql.res
+++ b/compiler/test-project-res/src/__generated__/UserMeta____relay_model_instance_graphql.res
@@ -29,6 +29,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #UserMeta____relay_model_instance]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #UserMeta____relay_model_instance]> =>
+    RescriptRelay_TestFragmentRef.make("UserMeta____relay_model_instance", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/UserName_user_graphql.res
+++ b/compiler/test-project-res/src/__generated__/UserName_user_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #UserName_user]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #UserName_user]> =>
+    RescriptRelay_TestFragmentRef.make("UserName_user", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types

--- a/compiler/test-project-res/src/__generated__/UserNode_node_graphql.res
+++ b/compiler/test-project-res/src/__generated__/UserNode_node_graphql.res
@@ -32,6 +32,11 @@ type fragmentRef
 external getFragmentRef:
   RescriptRelay.fragmentRefs<[> | #UserNode_node]> => fragmentRef = "%identity"
 
+module Test = {
+  let fromData = (data: Types.fragment): RescriptRelay.fragmentRefs<[> | #UserNode_node]> =>
+    RescriptRelay_TestFragmentRef.make("UserNode_node", data)
+}
+
 module Utils = {
   @@warning("-33")
   open Types


### PR DESCRIPTION
this allows to not export the `Fragment` from a relay component to keep fast refresh
this implementation also makes it typesafe